### PR TITLE
Switch to using hatchling build backend and use new license expression syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling>=1.27.0", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "python-msi"
@@ -16,7 +16,8 @@ description = "A pure Python library for reading and manipulating Windows Instal
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["pe", "installer", "ole", "msi"]
-license = { text = "MIT License" }
+license = "MIT"
+license-files = ["LICENSE", "NOTICE"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
@@ -34,7 +35,6 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: System",
     "Topic :: Utilities",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = ["olefile"]
 dynamic = ["version"]
@@ -54,8 +54,14 @@ Documentation = "https://pymsi.readthedocs.io/en/latest/"
 "Issue Tracker" = "https://github.com/nightlark/pymsi/issues"
 "Source Code" = "https://github.com/nightlark/pymsi"
 
-[tool.setuptools_scm]
-version_file = "src/pymsi/_version.py"
+[tool.hatch.build.targets.wheel]
+packages = ["src/pymsi"]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/pymsi/_version.py"
 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]


### PR DESCRIPTION
Python builds are warning about using license classifiers and using the new license expression syntax. This addresses those issues, and switches over to hatchling as the build backend (which supports the new syntax).