### PR TITLE
docs: note Python 3.8+ requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ pymsi is available on PyPI (PEP 541 request for pymsi name is being processed):
 pip install python-msi
 ```
 
-It is recommended to either install it in a virtual environment, or use a tool such as pipx or uv to avoid potential conflicts with other Python modules on the same system.
-
-pymsi requires **Python 3.8 or newer**.
+It is recommended to either install it in a virtual environment, or use a tool such as pipx or uv to avoid potential conflicts with other Python modules on the same system. Python 3.8 or newer is required.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ pip install python-msi
 
 It is recommended to either install it in a virtual environment, or use a tool such as pipx or uv to avoid potential conflicts with other Python modules on the same system.
 
+pymsi requires **Python 3.8 or newer**.
+
 ### Usage
 
 To use pymsi as a library that gets called from other code:


### PR DESCRIPTION
Adds a one-line note about the Python version requirement in the Installation section. The project specifies `requires-python = ">=3.8"` in `pyproject.toml` but this was not mentioned in the README.