### PR TITLE
Fix MSI binary column decoding and expose payload readers

### DIFF
--- a/src/pymsi/column.py
+++ b/src/pymsi/column.py
@@ -6,9 +6,12 @@ from pymsi.constants import (
     COL_NULLABLE_BIT,
     COL_PRIMARY_KEY_BIT,
     COL_STRING_BIT,
+    COL_VALID_BIT,
 )
 from pymsi.reader import BinaryReader
 from pymsi.stringpool import StringPool
+
+_BINARY_CELL = "<binary>"
 
 
 class Column:
@@ -36,7 +39,16 @@ class Column:
 
     def set_bits(self, bits: int):
         field_size = bits & COL_FIELD_SIZE_MASK
-        if bits & COL_STRING_BIT:
+        # Binary/OBJECT shares COL_STRING_BIT with strings, but its table cell
+        # is always a fixed-width 2-byte marker. The data lives in a
+        # "<Table>.<PrimaryKey>" OLE stream.
+        # https://gitlab.winehq.org/wine/wine/-/blob/master/dlls/msi/msipriv.h (MSITYPE_IS_BINARY)
+        # https://github.com/mdsteele/rust-msi/blob/master/src/internal/column.rs
+        is_binary = (bits & ~COL_NULLABLE_BIT) == (COL_STRING_BIT | COL_VALID_BIT)
+
+        if is_binary:
+            self.binary()
+        elif bits & COL_STRING_BIT:
             self.string(field_size)
         elif field_size == 4:
             self.i32()
@@ -71,6 +83,10 @@ class Column:
             if val == 0:
                 return None
             return val ^ -0x8000
+        elif self.type == "binary":
+            # The payload lives in a separate OLE stream.
+            reader.read_i16_le()
+            return _BINARY_CELL
         else:
             raise ValueError(f"Unknown column type: {self.type}")
 
@@ -116,6 +132,11 @@ class Column:
 
     def i16(self):
         self.type = "i16"
+        self.size = 2
+        return self
+
+    def binary(self):
+        self.type = "binary"
         self.size = 2
         return self
 

--- a/src/pymsi/msi/icon.py
+++ b/src/pymsi/msi/icon.py
@@ -1,8 +1,12 @@
-from typing import Dict
+from typing import Dict, Optional
 
 
 # https://learn.microsoft.com/en-us/windows/win32/msi/icon-table
 class Icon:
     def __init__(self, row: Dict):
         self.id: str = row["Name"]
-        self.data = row["Data"]
+        # Msi populates the external OBJECT stream when load_data=True.
+        self.data: Optional[bytes] = None
+
+    def _populate(self, data: bytes):
+        self.data = data

--- a/src/pymsi/msi/msi.py
+++ b/src/pymsi/msi/msi.py
@@ -30,6 +30,7 @@ class Msi:
 
         if load_data:
             self._load_media()
+            self._load_icons()
 
         self._populate_map(self.components, self.directories)
         self._populate_map(self.directories, self.directories)
@@ -71,6 +72,18 @@ class Msi:
                     processed.add(key)
             if len(map) == before_count:
                 break
+
+    def _load_icons(self):
+        table = self.package.get("Icon")
+        if table is None:
+            return
+
+        for row in table:
+            icon = self.icons[row["Name"]]
+            data = self.package.get_row_datastream_bytes(table, row)
+            if data is None:
+                raise ValueError(f"Icon data stream for {icon.id!r} not found in the .msi file")
+            icon._populate(data)
 
     def _load_media(self):
         for media in self.medias.values():

--- a/src/pymsi/msi/shortcut.py
+++ b/src/pymsi/msi/shortcut.py
@@ -46,7 +46,8 @@ class Shortcut:
         print(" " * (indent + 2) + f"Description: {self.description}")
         print(" " * (indent + 2) + f"Hotkey: {self.hotkey}")
         if self.icon:
-            print(" " * (indent + 2) + f"Icon: {self.icon.id} ({self.icon.data})")
+            data = "not loaded" if self.icon.data is None else f"{len(self.icon.data)} bytes"
+            print(" " * (indent + 2) + f"Icon: {self.icon.id} ({data})")
             print(" " * (indent + 2) + f"Icon Index: {self.icon_index}")
         else:
             print(" " * (indent + 2) + "Icon: None")

--- a/src/pymsi/package.py
+++ b/src/pymsi/package.py
@@ -2,7 +2,7 @@ import copy
 import io
 import mmap
 from pathlib import Path
-from typing import Iterator, Optional, Union
+from typing import Iterator, List, Mapping, Optional, Union
 
 import olefile
 
@@ -164,6 +164,50 @@ class Package:
                 # Stream does not exist
                 table.read_rows(None, self.string_pool)
         return table
+
+    def get_datastream_bytes(
+        self, table_name: str, *primary_keys: Union[str, int]
+    ) -> Optional[bytes]:
+        """Return the payload bytes for an MSI Binary/OBJECT table cell.
+
+        Binary payloads are stored in separate OLE streams.  Their logical
+        names are formed as ``<Table>.<Key1>[.<Key2>...]`` from the table name
+        and the row's primary-key values.  Returns ``None`` when the matching
+        stream does not exist.
+        """
+        if not table_name:
+            raise ValueError("table name must not be empty")
+        if not primary_keys:
+            raise ValueError("at least one primary-key value is required")
+        if not all(isinstance(value, (str, int)) for value in primary_keys):
+            raise TypeError("primary-key values must be strings or integers")
+
+        logical_name = ".".join(str(value) for value in (table_name, *primary_keys))
+        stream_name = streamname.encode_unicode(logical_name, False)
+        if not self.ole.exists(stream_name):
+            return None
+
+        with self.ole.openstream(stream_name) as stream:
+            return stream.read()
+
+    def get_row_datastream_bytes(self, table: Table, row: Mapping[str, object]) -> Optional[bytes]:
+        """Return Binary/OBJECT payload bytes for ``row`` using its primary key."""
+        if not any(column.type == "binary" for column in table.columns):
+            raise ValueError(f"Table {table.name!r} has no binary column")
+
+        primary_key_indices = table.primary_key_indices()
+        if not primary_key_indices:
+            raise ValueError(f"Table {table.name!r} has no primary-key columns")
+
+        primary_keys: List[Union[str, int]] = []
+        for index in primary_key_indices:
+            column_name = table.columns[index].name
+            value = row[column_name]
+            if not isinstance(value, (str, int)):
+                raise TypeError(f"Primary-key value {column_name!r} must be a string or integer")
+            primary_keys.append(value)
+
+        return self.get_datastream_bytes(table.name, *primary_keys)
 
     def __getitem__(self, name: str) -> Table:
         table = self.get(name)

--- a/tests/test_binary_columns.py
+++ b/tests/test_binary_columns.py
@@ -1,0 +1,243 @@
+import io
+from types import SimpleNamespace
+
+import pytest
+
+from pymsi import streamname
+from pymsi.column import Column
+from pymsi.constants import COL_NULLABLE_BIT, COL_STRING_BIT, COL_VALID_BIT
+from pymsi.msi.icon import Icon
+from pymsi.msi.msi import Msi
+from pymsi.msi.shortcut import Shortcut
+from pymsi.package import Package
+from pymsi.reader import BinaryReader
+from pymsi.table import Table
+
+
+class SizedBytesIO(io.BytesIO):
+    @property
+    def size(self):
+        return len(self.getbuffer())
+
+
+class FakeStringPool:
+    def __init__(self, long_string_refs):
+        self.long_string_refs = long_string_refs
+        self.calls = 0
+
+    def read_string(self, reader):
+        self.calls = 1
+        string_ref = reader.read_u16_le()
+        if self.long_string_refs:
+            string_ref |= reader.read_u8() << 16
+        return {1: "qgis.ico"}.get(string_ref)
+
+
+class FakeOle:
+    def __init__(self, streams):
+        self.streams = streams
+
+    def exists(self, name):
+        return name in self.streams
+
+    def openstream(self, name):
+        return io.BytesIO(self.streams[name])
+
+
+def binary_bits(nullable=False):
+    bits = COL_STRING_BIT | COL_VALID_BIT
+    if nullable:
+        bits |= COL_NULLABLE_BIT
+    return bits
+
+
+def icon_table(nullable=False):
+    return Table(
+        "Icon",
+        [
+            Column("Name").string(72).mark_primary_key(),
+            Column("Data", binary_bits(nullable)),
+        ],
+    )
+
+
+def package_with_streams(streams):
+    package = Package.__new__(Package)
+    package.ole = FakeOle(streams)
+    return package
+
+
+@pytest.mark.parametrize("nullable", [False, True])
+def test_binary_column_is_fixed_width(nullable):
+    column = icon_table(nullable).column("Data")
+
+    assert column.type == "binary"
+    assert column.width(long_string_refs=False) == 2
+    assert column.width(long_string_refs=True) == 2
+
+
+def test_long_string_ref_icon_row_is_five_bytes():
+    pool = FakeStringPool(long_string_refs=True)
+    data = SizedBytesIO(b"\x01\x00\x00\x01\x00")
+
+    rows = icon_table()._read_rows(BinaryReader(data), pool)
+
+    assert rows == [{"Name": "qgis.ico", "Data": "<binary>"}]
+    assert pool.calls == 1
+
+
+def test_short_string_ref_does_not_look_up_binary_marker():
+    pool = FakeStringPool(long_string_refs=False)
+    data = SizedBytesIO(b"\x01\x00\x01\x00")
+
+    rows = icon_table()._read_rows(BinaryReader(data), pool)
+
+    assert rows[0]["Data"] == "<binary>"
+    assert pool.calls == 1
+
+
+def test_genuinely_malformed_row_still_raises():
+    pool = FakeStringPool(long_string_refs=True)
+    data = SizedBytesIO(b"\x01\x00\x00\x01")
+
+    with pytest.raises(ValueError, match="not a multiple of row size"):
+        icon_table()._read_rows(BinaryReader(data), pool)
+
+
+def test_get_datastream_bytes_returns_bytes_or_none():
+    name = streamname.encode_unicode("Icon.qgis.ico", False)
+    package = package_with_streams({name: b"icon bytes"})
+
+    assert package.get_datastream_bytes("Icon", "qgis.ico") == b"icon bytes"
+    assert package.get_datastream_bytes("Icon", "missing.ico") is None
+
+
+def test_get_datastream_bytes_validates_stream_identity():
+    package = package_with_streams({})
+
+    with pytest.raises(ValueError, match="table name"):
+        package.get_datastream_bytes("", "key")
+    with pytest.raises(ValueError, match="at least one"):
+        package.get_datastream_bytes("Icon")
+    with pytest.raises(TypeError, match="strings or integers"):
+        package.get_datastream_bytes("Icon", None)
+
+
+def test_get_row_datastream_bytes_uses_primary_keys_in_column_order():
+    table = Table(
+        "Binary",
+        [
+            Column("First").string(32).mark_primary_key(),
+            Column("Second").i16().mark_primary_key(),
+            Column("Data").binary(),
+        ],
+    )
+    row = {"First": "alpha", "Second": 7, "Data": "<binary>"}
+    name = streamname.encode_unicode("Binary.alpha.7", False)
+    package = package_with_streams({name: b"payload"})
+
+    assert package.get_row_datastream_bytes(table, row) == b"payload"
+
+
+def test_get_row_datastream_bytes_validates_table_schema():
+    package = package_with_streams({})
+    no_binary = Table("Strings", [Column("Name").string(32).mark_primary_key()])
+    no_primary_key = Table("Binary", [Column("Data").binary()])
+
+    with pytest.raises(ValueError, match="no binary column"):
+        package.get_row_datastream_bytes(no_binary, {"Name": "value"})
+    with pytest.raises(ValueError, match="no primary-key columns"):
+        package.get_row_datastream_bytes(no_primary_key, {"Data": "<binary>"})
+
+
+def test_get_row_datastream_bytes_validates_primary_key_values():
+    table = Table(
+        "Binary",
+        [
+            Column("Name").string(32).mark_primary_key(),
+            Column("Data").binary(),
+        ],
+    )
+    package = package_with_streams({})
+
+    with pytest.raises(TypeError, match="Name"):
+        package.get_row_datastream_bytes(table, {"Name": None, "Data": "<binary>"})
+
+
+def test_icon_data_is_populated_separately_from_its_table_row():
+    icon = Icon({"Name": "qgis.ico", "Data": "<binary>"})
+
+    assert icon.data is None
+    icon._populate(b"icon bytes")
+    assert icon.data == b"icon bytes"
+
+
+def test_msi_load_icons_reads_and_populates_datastream_bytes():
+    table = icon_table()
+    row = {"Name": "qgis.ico", "Data": "<binary>"}
+    table.rows = [row]
+
+    class FakePackage:
+        def get(self, name):
+            assert name == "Icon"
+            return table
+
+        def get_row_datastream_bytes(self, requested_table, requested_row):
+            assert requested_table is table
+            assert requested_row is row
+            return b"icon bytes"
+
+    msi = Msi.__new__(Msi)
+    msi.package = FakePackage()
+    msi.icons = {"qgis.ico": Icon(row)}
+
+    msi._load_icons()
+
+    assert msi.icons["qgis.ico"].data == b"icon bytes"
+
+
+def test_msi_load_icons_rejects_missing_payload_stream():
+    table = icon_table()
+    row = {"Name": "qgis.ico", "Data": "<binary>"}
+    table.rows = [row]
+
+    class FakePackage:
+        def get(self, name):
+            return table
+
+        def get_row_datastream_bytes(self, requested_table, requested_row):
+            return None
+
+    msi = Msi.__new__(Msi)
+    msi.package = FakePackage()
+    msi.icons = {"qgis.ico": Icon(row)}
+
+    with pytest.raises(ValueError, match="qgis.ico"):
+        msi._load_icons()
+
+
+def test_shortcut_pretty_print_summarizes_loaded_icon_bytes(capsys):
+    icon = Icon({"Name": "qgis.ico", "Data": "<binary>"})
+    icon._populate(b"\x00\x01\x02")
+
+    shortcut = Shortcut.__new__(Shortcut)
+    shortcut.id = "Shortcut"
+    shortcut.name = "QGIS"
+    shortcut.target = "[#qgis.exe]"
+    shortcut.arguments = None
+    shortcut.description = None
+    shortcut.hotkey = None
+    shortcut.icon = icon
+    shortcut.icon_index = 0
+    shortcut.show_command = 1
+    shortcut.working_directory = "INSTALLDIR"
+    shortcut.component = SimpleNamespace(
+        id="Component", directory=SimpleNamespace(name="INSTALLDIR")
+    )
+    shortcut.directory = SimpleNamespace(name="INSTALLDIR", id="INSTALLDIR")
+
+    shortcut.pretty_print()
+
+    output = capsys.readouterr().out
+    assert "Icon: qgis.ico (3 bytes)" in output
+    assert "b'\\x00\\x01\\x02'" not in output

--- a/tests/test_binary_columns_reproduction.py
+++ b/tests/test_binary_columns_reproduction.py
@@ -1,0 +1,131 @@
+# ---------------------------------------------------------------------------
+# Regression tests for binary (object/stream) columns as observed with QGIS installers.
+# May have significant overlap with test_binary_columns.py
+# Root cause of https://github.com/nightlark/pymsi/issues/160: binary columns
+# (e.g. Icon.Data, type bits 0x0900, declared "v0") are always 2 bytes on disk,
+# even when the string pool uses 3-byte long string refs. pymsi treated them as
+# string refs, computing row_size=6 for the Icon table when the on-disk row is
+# actually 5 bytes (3-byte Name ref + 2-byte Data marker).
+# Reference: Wine dlls/msi/table.c bytes_per_column() and rust-msi column.rs.
+# ---------------------------------------------------------------------------
+
+import io
+import struct
+
+import pytest
+
+from pymsi.column import Column
+from pymsi.reader import BinaryReader
+from pymsi.stringpool import StringPool
+from pymsi.table import Table
+
+
+class _FakeStream:
+    """Minimal stream satisfying BinaryReader's interface (mirrors OleStream)."""
+
+    def __init__(self, data: bytes):
+        self._bio = io.BytesIO(data)
+        self.size = len(data)  # OleStream exposes size as an attribute
+
+    def read(self, n=-1):
+        return self._bio.read(n)
+
+    def tell(self):
+        return self._bio.tell()
+
+    def seek(self, pos):
+        self._bio.seek(pos)
+
+
+def _make_string_pool(strings, long_refs: bool):
+    """Build a real StringPool from synthetic _StringPool/_StringData streams."""
+    codepage = 1252 | (0x8000_0000 if long_refs else 0)
+    pool = struct.pack("<I", codepage)
+    data = b""
+    for s in strings:
+        raw = s.encode("cp1252")
+        pool += struct.pack("<HH", len(raw), 1)
+        data += raw
+    return StringPool(_FakeStream(pool), _FakeStream(data))
+
+
+ICON_TYPE_BITS_NAME = 0x2D48  # s72, primary key (observed in QGIS MSIs)
+ICON_TYPE_BITS_DATA = 0x0900  # v0 binary column (observed in QGIS MSIs)
+
+
+def _make_icon_table():
+    return Table(
+        "Icon",
+        [
+            Column("Name", ICON_TYPE_BITS_NAME),
+            Column("Data", ICON_TYPE_BITS_DATA),
+        ],
+    )
+
+
+def test_binary_column_type_detection():
+    col = Column("Data", ICON_TYPE_BITS_DATA)
+    assert col.type == "binary"
+    # Nullable binary columns are still binary (Wine masks MSITYPE_NULLABLE)
+    col = Column("Data", ICON_TYPE_BITS_DATA | 0x1000)
+    assert col.type == "binary"
+    # Regular string columns are unaffected
+    col = Column("Name", ICON_TYPE_BITS_NAME)
+    assert col.type == "str"
+
+
+def test_binary_column_width_ignores_long_string_refs():
+    """Binary columns are 2 bytes on disk regardless of string-ref width
+    (Wine table.c bytes_per_column: MSITYPE_IS_BINARY -> 2)."""
+    col = Column("Data", ICON_TYPE_BITS_DATA)
+    assert col.width(long_string_refs=False) == 2
+    assert col.width(long_string_refs=True) == 2
+
+
+def test_icon_table_row_size_with_long_string_refs():
+    table = _make_icon_table()
+    pool = _make_string_pool(["icon.ico"], long_refs=True)
+    row_size = sum(c.width(pool.long_string_refs) for c in table.columns)
+    assert row_size == 5  # 3-byte string ref + 2-byte binary marker
+
+
+def test_icon_table_qgis_scenario_parses_one_row():
+    """Reproduces the exact on-disk layout of the QGIS Icon table: a 5-byte
+    stream under long string refs holding one row ('icon.ico', present)."""
+    table = _make_icon_table()
+    pool = _make_string_pool(["icon.ico"], long_refs=True)
+    # Column-major stream: Name strref (3 bytes, ref 1 -> first string) then
+    # Data cell (2 bytes, 1 = data present). QGIS 3.40.15's actual stream is
+    # 89 c4 02 01 00 with ref 181385; here the pool has one string so ref=1.
+    data = struct.pack("<HB", 1, 0) + struct.pack("<H", 1)
+    assert len(data) == 5
+    rows = table._read_rows(BinaryReader(_FakeStream(data)), pool)  # strict default
+    assert rows == [{"Name": "icon.ico", "Data": "<binary>"}]
+
+
+def test_binary_column_short_string_refs_value_not_misread_as_string():
+    """With 2-byte refs the widths coincidentally matched, but the old code
+    decoded the binary cell as a string ref; it must stay an int marker."""
+    table = _make_icon_table()
+    pool = _make_string_pool(["icon.ico"], long_refs=False)
+    data = struct.pack("<H", 1) + struct.pack("<H", 1)  # ref 1, marker 1
+    rows = table._read_rows(BinaryReader(_FakeStream(data)), pool)
+    assert rows == [{"Name": "icon.ico", "Data": "<binary>"}]
+
+
+def _make_int_table():
+    """Two i16 columns (row_size=4); values are stored biased by 0x8000."""
+    return Table("TestTable", [Column("A").i16(), Column("B").i16()])
+
+
+def _bias16(v):
+    return (v ^ -0x8000) & 0xFFFF
+
+
+def test_read_rows_strict_raises_on_bad_length():
+    table = _make_int_table()  # row_size = 4
+    pool = _make_string_pool([], long_refs=False)
+    # 9 bytes: 8 bytes of cell data + 1 trailing byte
+    data = struct.pack("<4H", *(_bias16(v) for v in (1, 2, 3, 4))) + b"\x00"
+    with pytest.raises(ValueError, match="not a multiple of row size"):
+        table._read_rows(BinaryReader(_FakeStream(data)), pool)


### PR DESCRIPTION
MSI Binary/OBJECT columns share the string type bit, but their table cells are always fixed-width two-byte markers. They must be classified before ordinary strings so long string refs don't result in an incorrect row width or perform a lookup of the marker in the string pool. Handling has been checked against rust-msi and msitools/wine.

Expose package-level get_datastream_bytes() and get_row_datastream_bytes() helper methods for reading the external OLE payload, and populate Icon.data with bytes only when Msi load_data is enabled.

Uses a <binary> placeholder to mark Binary cells, similar to rust-msi returning a Binary marker type.

Add tests for long/short string refs, payload lookup, composite primary keys, icon loading, missing streams, and some malformed rows.

Fixes #160.