### PR TITLE
Hide RTD version flyout when it covers the MSI viewer

### DIFF
--- a/docs/_static/msi_viewer.js
+++ b/docs/_static/msi_viewer.js
@@ -9,6 +9,7 @@ class MSIViewer {
     this.currentMsi = null;
     this.currentFileName = null;
     this.initElements();
+    this.initReadTheDocsFlyoutOverlapGuard();
     this.initEventListeners();
     this.loadPyodide();
   }
@@ -412,6 +413,132 @@ class MSIViewer {
     }
   }
 
+  // Hide Read the Docs' floating flyout whenever it would cover the viewer.
+  initReadTheDocsFlyoutOverlapGuard() {
+    const viewer = document.getElementById('msi-viewer-app');
+    if (!viewer) return;
+
+    let animationFrame = null;
+    let flyout = null;
+    let flyoutBox = null;
+    let shadowObserver = null;
+
+    const resizeObserver = typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(scheduleUpdate);
+
+    function rectanglesOverlap(first, second) {
+      return (
+        first.width > 0 &&
+        first.height > 0 &&
+        second.width > 0 &&
+        second.height > 0 &&
+        first.left < second.right &&
+        first.right > second.left &&
+        first.top < second.bottom &&
+        first.bottom > second.top
+      );
+    }
+
+    function setFlyoutBox(nextBox) {
+      if (nextBox === flyoutBox) return;
+
+      if (flyoutBox && resizeObserver) {
+        resizeObserver.unobserve(flyoutBox);
+      }
+      flyoutBox = nextBox;
+      if (flyoutBox && resizeObserver) {
+        resizeObserver.observe(flyoutBox);
+      }
+    }
+
+    function bindFlyout() {
+      const nextFlyout = document.querySelector('readthedocs-flyout');
+      if (nextFlyout !== flyout) {
+        setFlyoutBox(null);
+        if (shadowObserver) {
+          shadowObserver.disconnect();
+          shadowObserver = null;
+        }
+        flyout = nextFlyout;
+      }
+
+      if (!flyout) return;
+
+      const shadowRoot = flyout.shadowRoot;
+      if (shadowRoot && !shadowObserver) {
+        shadowObserver = new MutationObserver(() => {
+          bindFlyout();
+          scheduleUpdate();
+        });
+        shadowObserver.observe(shadowRoot, {
+          attributes: true,
+          attributeFilter: ['class', 'style'],
+          childList: true,
+          subtree: true,
+        });
+      }
+
+      setFlyoutBox(
+        shadowRoot?.querySelector('.container') ||
+        shadowRoot?.firstElementChild ||
+        flyout
+      );
+    }
+
+    function update() {
+      animationFrame = null;
+      bindFlyout();
+      if (!flyout) return;
+
+      let overlaps = viewer.classList.contains('fullscreen-mode');
+      if (!overlaps && flyoutBox) {
+        overlaps = rectanglesOverlap(
+          viewer.getBoundingClientRect(),
+          flyoutBox.getBoundingClientRect()
+        );
+      }
+      flyout.toggleAttribute('data-pymsi-overlaps-viewer', overlaps);
+    }
+
+    function scheduleUpdate() {
+      if (animationFrame !== null) return;
+      animationFrame = window.requestAnimationFrame(update);
+    }
+
+    if (resizeObserver) {
+      resizeObserver.observe(viewer);
+    }
+
+    // Read the Docs injects the flyout as a direct child of <body>.
+    const bodyObserver = new MutationObserver(() => {
+      bindFlyout();
+      scheduleUpdate();
+    });
+    bodyObserver.observe(document.body, { childList: true });
+
+    window.addEventListener('resize', scheduleUpdate, { passive: true });
+    window.addEventListener('scroll', scheduleUpdate, {
+      capture: true,
+      passive: true,
+    });
+    document.addEventListener(
+      'readthedocs-addons-data-ready',
+      scheduleUpdate
+    );
+
+    if (window.customElements) {
+      window.customElements.whenDefined('readthedocs-flyout').then(() => {
+        bindFlyout();
+        scheduleUpdate();
+      });
+    }
+
+    this.scheduleReadTheDocsFlyoutVisibilityUpdate = scheduleUpdate;
+    bindFlyout();
+    scheduleUpdate();
+  }
+
   // Toggle fullscreen mode
   toggleFullscreen() {
     const app = document.getElementById('msi-viewer-app');
@@ -444,6 +571,10 @@ class MSIViewer {
 
       // Update button text/icon
       this.fullscreenToggle.innerHTML = '<span class="icon">⛶</span> Fullscreen';
+    }
+
+    if (this.scheduleReadTheDocsFlyoutVisibilityUpdate) {
+      this.scheduleReadTheDocsFlyoutVisibilityUpdate();
     }
   }
 

--- a/docs/msi_viewer.md
+++ b/docs/msi_viewer.md
@@ -162,6 +162,12 @@ Like this tool and want to help out?
     box-sizing: border-box;
   }
 
+  /* Keep the flyout laid out so overlap checks can make it visible again. */
+  readthedocs-flyout[data-pymsi-overlaps-viewer] {
+    visibility: hidden !important;
+    pointer-events: none !important;
+  }
+
   .toolbar {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
This change makes so the ReadTheDocs version picker flyout that gets injected as part of RTD builds will be hidden if it ever overlaps the MSI viewer (e.g. browser window gets resizes to not have a large gutter for it to live in, fullscreen mode entered, or on mobile/tablet screens).