### PR TITLE
Change PyPI package name to pymsi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     environment:
       name: pypi
-      url: https://pypi.org/p/python-msi
+      url: https://pypi.org/p/pymsi
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 # pymsi
 
-[![PyPI](https://img.shields.io/pypi/v/python-msi)](https://pypi.org/project/python-msi/)
-[![PyPI - Downloads](https://static.pepy.tech/personalized-badge/python-msi?period=monthly&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=GREEN&left_text=downloads%2Fmonth)](https://pypi.org/project/python-msi/)
-[![MIT License](https://img.shields.io/pypi/l/python-msi.svg)](https://github.com/nightlark/pymsi/blob/main/LICENSE)
-[![Python Versions](https://img.shields.io/pypi/pyversions/python-msi.svg)](https://pypi.org/project/python-msi/)
+[![PyPI](https://img.shields.io/pypi/v/pymsi)](https://pypi.org/project/pymsi/)
+[![PyPI - Downloads](https://static.pepy.tech/personalized-badge/python-msi?period=monthly&units=INTERNATIONAL_SYSTEM&left_color=GREY&right_color=GREEN&left_text=downloads%2Fmonth)](https://pypi.org/project/pymsi/)
+[![MIT License](https://img.shields.io/pypi/l/pymsi.svg)](https://github.com/nightlark/pymsi/blob/main/LICENSE)
+[![Python Versions](https://img.shields.io/pypi/pyversions/pymsi.svg)](https://pypi.org/project/pymsi/)
 [![CI](https://github.com/nightlark/pymsi/actions/workflows/ci.yml/badge.svg)](https://github.com/nightlark/pymsi/actions)
 [![Documentation Status](https://readthedocs.org/projects/pymsi/badge/?version=latest)](https://pymsi.readthedocs.io/en/latest/?badge=latest)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/nightlark/pymsi/main.svg)](https://results.pre-commit.ci/latest/github/nightlark/pymsi/main)
@@ -22,10 +22,10 @@ For more in-depth documentation on pymsi usage and the API, see the [documentati
 
 ### Installation
 
-pymsi is available on PyPI (PEP 541 request for pymsi name is being processed):
+pymsi is available on PyPI:
 
 ```sh
-pip install python-msi
+pip install pymsi
 ```
 
 It is recommended to either install it in a virtual environment, or use a tool such as pipx or uv to avoid potential conflicts with other Python modules on the same system.
@@ -51,6 +51,9 @@ Available commands:
   tables - List all tables in the MSI file
   dump - Dump the contents of the MSI file
   test - Check if the file is a valid MSI file
+  suminfo - Print summary information
+  customactions (ca) - Decode custom actions and static invocation sites
+  analyze - Summarize installer behavior for review
   extract - Extract files from the MSI file
   help - Show this help message
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling>=1.27.0", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
-name = "python-msi"
+name = "pymsi"
 authors = [
     { name = "Asriel Camora", email = "asriel@camora.dev" },
     { name = "Ryan Mast", email = "mast.ryan@gmail.com" },


### PR DESCRIPTION
Change the pyproject.toml package name to `pymsi` for publishing under the new name.